### PR TITLE
Remove unused comment

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -11,7 +11,6 @@ $config
         '@PSR12' => true,
         'array_push' => true,
         'no_unused_imports' => true,
-        // TODO: Add PHPStan and enable declare_strict_Types
         'declare_strict_types' => true,
         'strict_comparison' => true,
         'strict_param' => true,


### PR DESCRIPTION
Comment doesn't has any value at this point. The `declare_strict_types` flag is set to true so strict types are enforced in all files. If we introduce phpstan at some point in the future this behavior won't change.