### PR TITLE
Change enum values notations

### DIFF
--- a/src/ElementalGrid/ElementListItems.php
+++ b/src/ElementalGrid/ElementListItems.php
@@ -44,7 +44,7 @@ class ElementListItems extends BaseElement
      * @config
      */
     private static array $db = [
-        'Mode' => 'Enum(["Custom", "Collection"], "Collection")',
+        'Mode' => 'Enum(array("Custom", "Collection"), "Collection")',
     ];
 
     /**


### PR DESCRIPTION
There seem to be a bug with Enum array parsing in the framework https://github.com/silverstripe/silverstripe-framework/issues/10435, as a precaution switch to a notation that doesn't break by this issue.